### PR TITLE
Please make the documentation reproducible.

### DIFF
--- a/octaviaclient/osc/v2/amphora.py
+++ b/octaviaclient/osc/v2/amphora.py
@@ -43,7 +43,7 @@ class ListAmphora(lister.Lister):
         role_choices = {'MASTER', 'BACKUP', 'STANDALONE'}
         parser.add_argument(
             '--role',
-            metavar='{' + ','.join(role_choices) + '}',
+            metavar='{' + ','.join(sorted(role_choices)) + '}',
             choices=role_choices,
             type=lambda s: s.upper(),  # case insensitive
             help="Filter by role."
@@ -56,7 +56,7 @@ class ListAmphora(lister.Lister):
         parser.add_argument(
             '--status', '--provisioning-status',
             dest='status',
-            metavar='{' + ','.join(status_choices) + '}',
+            metavar='{' + ','.join(sorted(status_choices)) + '}',
             choices=status_choices,
             type=lambda s: s.upper(),  # case insensitive
             help="Filter by amphora provisioning status."


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org) effort, we noticed that `python-octaviaclient` could not be built reproducibly.

This is because it iterates over a set in a nondeterminstic manner when generating its own documentation.

This was originally filed in @Debian as [#921511](https://bugs.debian.org/921511).